### PR TITLE
Fix finals tab curves

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,4 @@ Have the JSON key file path of a Firebase service account pointed by an env var 
 
 - In standings, check the correct name between either "numGoalDiff" or "numGoalsDiff".
 - In standings, the championship field is just the championship type, missing the edition.
+- Delete counter.js

--- a/index.html
+++ b/index.html
@@ -5,6 +5,13 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Button Football</title>
+    <link rel="stylesheet" type="text/css" href="./css/styles.css">
+    
+    <!-- TODO: review disabling of caching -->
+    <!-- Disable caching -->
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
   </head>
   <body>
     <div id="app" class="container py-4 px-3 mx-auto"></div>

--- a/src/main/resources/css/styles.css
+++ b/src/main/resources/css/styles.css
@@ -1,15 +1,14 @@
 .img-container-40 {
-  width: 40px;
-  height: 40px;
-  display: flex;
+  display: block;
   justify-content: center;
   align-items: center;
   background-color: #f0f0f0;
-  overflow: hidden;
 }
 
 .img-container-40 img {
+  width: 40px;
+  height: 40px;
   max-width: 100%;
   max-height: 100%;
-  object-fit: contain;
+  object-fit: none;
 }

--- a/src/main/resources/css/styles.css
+++ b/src/main/resources/css/styles.css
@@ -1,14 +1,5 @@
-.img-container-40 {
-  display: block;
-  justify-content: center;
-  align-items: center;
-  background-color: #f0f0f0;
-}
-
-.img-container-40 img {
+.logo-40 {
   width: 40px;
   height: 40px;
-  max-width: 100%;
-  max-height: 100%;
   object-fit: none;
 }

--- a/src/main/scala/com/talestonini/buttonfootball/Main.scala
+++ b/src/main/scala/com/talestonini/buttonfootball/Main.scala
@@ -165,10 +165,10 @@ def renderChampionshipEditionsRange(): Element =
           cls := "form-range",
           typ := "range",
           minAttr <-- championships.signal.map(cs =>
-            (if (!cs.isEmpty) MIN_CHAMPIONSHIP_EDITION else NO_CHAMPIONSHIP_EDITION).toString()
+            (if (cs.nonEmpty) MIN_CHAMPIONSHIP_EDITION else NO_CHAMPIONSHIP_EDITION).toString
           ),
           maxAttr <-- championships.signal.map(cs => 
-            (if (!cs.isEmpty) cs.length else NO_CHAMPIONSHIP_EDITION).toString()),
+            (if (cs.nonEmpty) cs.length else NO_CHAMPIONSHIP_EDITION).toString),
           onChange.mapToValue --> { edition =>
             selectedChampionship.update(_ => championships.now().find((ce) => ce.numEdition == edition.toInt))
             seGetMatches(selectedChampionship.now().getOrElse(NO_CHAMPIONSHIP).id)
@@ -285,7 +285,7 @@ def assertCorrectNumQualifAndFinalsMatches(): Signal[String] =
     .combineWith(numTeams)
     .map { case (sc, nfm, nt) => "Number of qualified teams: " + (calcNumQualif(nt) match {
       case Left(e) =>
-        s"error (${e.getMessage()})"
+        s"error (${e.getMessage})"
       case Right(calcNumQualif) =>
         val dbNumQualif = sc.getOrElse(NO_CHAMPIONSHIP).numQualif
         val res = if (dbNumQualif == calcNumQualif && nfm == calcNumQualif) "" else "in"

--- a/src/main/scala/com/talestonini/buttonfootball/Main.scala
+++ b/src/main/scala/com/talestonini/buttonfootball/Main.scala
@@ -9,12 +9,10 @@ import com.talestonini.buttonfootball.component.TTTable.TTHeader
 import com.talestonini.buttonfootball.model.*
 import com.talestonini.buttonfootball.model.Championships.*
 import com.talestonini.buttonfootball.model.ChampionshipTypes.*
-import com.talestonini.buttonfootball.model.Matches.*
 import com.talestonini.buttonfootball.model.Standings.*
-import com.talestonini.buttonfootball.model.Teams.*
 import com.talestonini.buttonfootball.model.TeamTypes.*
 import com.talestonini.buttonfootball.service.ChampionshipService.calcNumQualif
-import com.talestonini.buttonfootball.component.FinalsMatchesTabContent.{rows, cols}
+import com.talestonini.buttonfootball.component.FinalsMatchesTabContent.{rows, cols, staticCellLinks}
 import org.scalajs.dom
 
 @main
@@ -26,7 +24,7 @@ def ButtonFootballFrontEnd(): Unit =
     div(
       cls := "container",
       styleAttr := "height: 110px;",
-      renderStateForInspection(),
+      renderStateForInspection(true),
       h1("Jogo de Botão"),
       div(
         cls := "row h-100",
@@ -91,7 +89,8 @@ def renderStateForInspection(isEnabled: Boolean = false) =
         child.text <-- groupStandings.signal.combineWith(finalStandings.signal).map {
           case(gss, fss) => s"Group Standings: ${gss.size}, Final Standings: ${fss.size}"
         }
-      )
+      ),
+      div(child.text <-- staticCellLinks.signal.map(scl => s"Static cell links size: ${scl.size}")),
     )
 
 def renderTeamTypeRadios(): Element =

--- a/src/main/scala/com/talestonini/buttonfootball/Main.scala
+++ b/src/main/scala/com/talestonini/buttonfootball/Main.scala
@@ -17,37 +17,44 @@ import org.scalajs.dom
 
 @main
 def ButtonFootballFrontEnd(): Unit =
+  // seGetTeams()
   seGetTeamTypes()
   FinalsMatchesTabContent.setupAutoReRenderOfCellLinksOnWindowEvents()
   renderOnDomContentLoaded(
     dom.document.getElementById("app"),
     div(
-      cls := "container",
-      styleAttr := "height: 110px;",
-      renderStateForInspection(true),
-      h1("Jogo de Botão"),
-      div(
-        cls := "row h-100",
-        renderTeamTypeRadios().wrap("col-auto h-100 d-flex"),
-        renderChampionshipTypeSelect().wrap("col h-100 d-flex"),
-      ),
-      renderChampionshipEditionsRange().wrap("row h-100"),
-      renderMatchesTabs(),
-      // input(
-      //   typ := "text",
-      //   value <-- teamName,
-      //   onInput.mapToValue --> teamName,
-      //   onChange --> (ev => seGetTeams(teamName.now()))
-      // ),
-      // TTTable.renderTable(teams, List(
-      //   TTHeader("Nome", 1),
-      //   TTHeader("Tipo", 2),
-      //   TTHeader("Nome Completo", 3),
-      //   TTHeader("Fundação", 4),
-      //   TTHeader("Cidade", 5),
-      //   TTHeader("País", 6)
-      // ))
+      // children <-- teams.signal.map(ts => ts.map(t => img(src := Logo.forTeam(t.logoImgFile)))),
+      mainAppElement()
     )
+  )
+
+def mainAppElement(): Element =
+  div(
+    cls := "container",
+    styleAttr := "height: 110px;",
+    renderStateForInspection(),
+    h1("Jogo de Botão"),
+    div(
+      cls := "row h-100",
+      renderTeamTypeRadios().wrap("col-auto h-100 d-flex"),
+      renderChampionshipTypeSelect().wrap("col h-100 d-flex"),
+    ),
+    renderChampionshipEditionsRange().wrap("row h-100"),
+    renderMatchesTabs(),
+    // input(
+    //   typ := "text",
+    //   value <-- teamName,
+    //   onInput.mapToValue --> teamName,
+    //   onChange --> (ev => seGetTeams(teamName.now()))
+    // ),
+    // TTTable.renderTable(teams, List(
+    //   TTHeader("Nome", 1),
+    //   TTHeader("Tipo", 2),
+    //   TTHeader("Nome Completo", 3),
+    //   TTHeader("Fundação", 4),
+    //   TTHeader("Cidade", 5),
+    //   TTHeader("País", 6)
+    // ))
   )
 
 // --- rendering functions ---------------------------------------------------------------------------------------------
@@ -91,6 +98,7 @@ def renderStateForInspection(isEnabled: Boolean = false) =
         }
       ),
       div(child.text <-- staticCellLinks.signal.map(scl => s"Static cell links size: ${scl.size}")),
+      div(child.text <-- teams.signal.map(ts => s"Teams count: ${ts.size}"))
     )
 
 def renderTeamTypeRadios(): Element =

--- a/src/main/scala/com/talestonini/buttonfootball/component/FinalsMatchesTabContent.scala
+++ b/src/main/scala/com/talestonini/buttonfootball/component/FinalsMatchesTabContent.scala
@@ -232,12 +232,10 @@ object FinalsMatchesTabContent:
     ).toList()}
   
   private def renderStaticCellLinks(): Unit = 
-    println("rendering static cell links...")
     staticCellLinks.now().foreach { cl => {
       val cellLinkElem = dom.document.getElementById(cellLinkAddressFn(cl.fromCell, cl.toCell))
       if (cellLinkElem != null) cellLinkElem.setAttribute("d", bezierCurveCommands(cl.fromCell, cl.toCell))
     }}
-  end renderStaticCellLinks
 
   private def bezierCurveCommands(fromCell: Cell, toCell: Cell): String = {
     val fromRect      = fromCell.rect()

--- a/src/main/scala/com/talestonini/buttonfootball/component/FinalsMatchesTabContent.scala
+++ b/src/main/scala/com/talestonini/buttonfootball/component/FinalsMatchesTabContent.scala
@@ -231,7 +231,7 @@ object FinalsMatchesTabContent:
         )
     ).toList()}
   
-  def renderStaticCellLinks(): Unit = 
+  private def renderStaticCellLinks(): Unit = 
     println("rendering static cell links...")
     staticCellLinks.now().foreach { cl => {
       val cellLinkElem = dom.document.getElementById(cellLinkAddressFn(cl.fromCell, cl.toCell))

--- a/src/main/scala/com/talestonini/buttonfootball/component/FinalsMatchesTabContent.scala
+++ b/src/main/scala/com/talestonini/buttonfootball/component/FinalsMatchesTabContent.scala
@@ -74,7 +74,7 @@ object FinalsMatchesTabContent:
   private val maxRow: Signal[Int] = rows.map(rs => if (!rs.isEmpty) rs.last else minRow)
 
   private val cellAddressFn = (col: Char, row: Int) => s"$col$row"
-  private case class Cell(col: Char, row: Int) {
+  case class Cell(col: Char, row: Int) {
     def address(): String = cellAddressFn(col, row)
     def rect(): DOMRect = dom.document.getElementById(address()).getBoundingClientRect()
   }
@@ -162,10 +162,10 @@ object FinalsMatchesTabContent:
         }
 
         def saveStaticCellLinks(tree: Tree[MatchCell]): Unit =
-          staticCellLinks = tree.toList().flatMap(n =>
+          staticCellLinks.update(_ => tree.toList().flatMap(n =>
             if (n.toCells.isEmpty) List.empty
             else List(CellLink(n.cell, n.toCells.head), CellLink(n.cell, n.toCells.tail.head))
-          )
+          ))
     
         setTreeRootFinalMatch(tree)
         saveStaticCellLinks(tree)
@@ -200,8 +200,8 @@ object FinalsMatchesTabContent:
     * scrolled or resized, re-render of the cell links (curves) is driven by the saved static cell links, as opposed to
     * signals, which are not available then.
     */
-  private case class CellLink(fromCell: Cell, toCell: Cell)
-  private var staticCellLinks: List[CellLink] = List.empty
+  case class CellLink(fromCell: Cell, toCell: Cell)
+  val staticCellLinks: Var[List[CellLink]] = Var(List.empty)
 
   private val cellLinkAddressFn = (fromCell: Cell, toCell: Cell) => s"${fromCell.address()}-${toCell.address()}"
   private def renderCellLinks(): Signal[List[Element]] =
@@ -231,11 +231,13 @@ object FinalsMatchesTabContent:
         )
     ).toList()}
   
-  private def renderStaticCellLinks(): Unit = staticCellLinks.foreach { cl =>
-    dom.document
-      .getElementById(cellLinkAddressFn(cl.fromCell, cl.toCell))
-      .setAttribute("d", bezierCurveCommands(cl.fromCell, cl.toCell))
-  }
+  def renderStaticCellLinks(): Unit = 
+    println("rendering static cell links...")
+    staticCellLinks.now().foreach { cl => {
+      val cellLinkElem = dom.document.getElementById(cellLinkAddressFn(cl.fromCell, cl.toCell))
+      if (cellLinkElem != null) cellLinkElem.setAttribute("d", bezierCurveCommands(cl.fromCell, cl.toCell))
+    }}
+  end renderStaticCellLinks
 
   private def bezierCurveCommands(fromCell: Cell, toCell: Cell): String = {
     val fromRect      = fromCell.rect()
@@ -253,9 +255,10 @@ object FinalsMatchesTabContent:
     * Sets up re-rendering of the SVG Bézier curves when the window is resized or scrolled or double-clicked (mobile).
     */
   def setupAutoReRenderOfCellLinksOnWindowEvents(): Unit = {
-    dom.window.addEventListener("scroll", (_: dom.Event) => renderStaticCellLinks())
-    dom.window.addEventListener("resize", (_: dom.Event) => renderStaticCellLinks())
-    dom.window.addEventListener("dblclick", (_: dom.Event) => renderStaticCellLinks())
+    val eventFn: dom.Event => Unit = _ => renderStaticCellLinks()
+    dom.window.addEventListener("scroll", eventFn)
+    dom.window.addEventListener("resize", eventFn)
+    dom.window.addEventListener("dblclick", eventFn)
   }
   
   def apply(): Element =

--- a/src/main/scala/com/talestonini/buttonfootball/component/MatchElement.scala
+++ b/src/main/scala/com/talestonini/buttonfootball/component/MatchElement.scala
@@ -8,7 +8,7 @@ object MatchElement:
 
   def apply(m: Match, isFinalsStage: Boolean = false): Element =
     def displayInFinals(condition: Boolean) = display(if (isFinalsStage && condition) "table-cell" else "none")
-    def logo(logoImgFile: String): Element = td(cls := "img-container-40", img(src := Logo.forTeam(logoImgFile)))
+    def logo(logoImgFile: String): Element = td(img(cls := "logo-40", src := Logo.forTeam(logoImgFile)))
 
     tr(
       cls := "text-center",

--- a/src/main/scala/com/talestonini/buttonfootball/component/MatchElement.scala
+++ b/src/main/scala/com/talestonini/buttonfootball/component/MatchElement.scala
@@ -8,7 +8,7 @@ object MatchElement:
 
   def apply(m: Match, isFinalsStage: Boolean = false): Element =
     def displayInFinals(condition: Boolean) = display(if (isFinalsStage && condition) "table-cell" else "none")
-    def logo(logoImgFile: String): Element = td(img(cls := "img-container-40", src := Logo.forTeam(logoImgFile)))
+    def logo(logoImgFile: String): Element = td(cls := "img-container-40", img(src := Logo.forTeam(logoImgFile)))
 
     tr(
       cls := "text-center",

--- a/src/main/scala/com/talestonini/buttonfootball/model/package.scala
+++ b/src/main/scala/com/talestonini/buttonfootball/model/package.scala
@@ -195,7 +195,7 @@ package object model:
       })(queue)
   end seGetFinalStandings
 
-  def seGetTeams(name: String): Unit =
+  def seGetTeams(name: String = ""): Unit =
     println(s"fetching team with name '$name'")
     TeamService
       .getTeams(if (name.isBlank()) None else Some(name.trim()))


### PR DESCRIPTION
This pull request includes various updates across multiple files to improve functionality and maintainability. The changes include updates to HTML and CSS files, Scala code refactoring, and improvements to rendering functions.

### HTML and CSS Updates:
* Added a link to the stylesheet and disabled caching in `index.html` to ensure the latest version of the page is always loaded.
* Renamed and simplified CSS class `.img-container-40` to `.logo-40` in `styles.css` to improve code readability and maintainability.

### Scala Code Refactoring:
* Removed unused imports and added new imports in `Main.scala` to clean up the code and include necessary components.
* Updated the `renderStateForInspection` method to include additional information about static cell links and teams count.
* Modified the `renderChampionshipEditionsRange` method to use a more concise syntax for checking non-empty lists.
* Changed the `assertCorrectNumQualifAndFinalsMatches` method to use a more concise syntax for error message retrieval.

### FinalsMatchesTabContent Improvements:
* Made `Cell` and `CellLink` case classes public and updated `staticCellLinks` to use a `Var` for better state management. [[1]](diffhunk://#diff-c17c8f8eb6ccd92bfd9ea0081745d65fbc193495c3cd74d7091808142a7df891L77-R77) [[2]](diffhunk://#diff-c17c8f8eb6ccd92bfd9ea0081745d65fbc193495c3cd74d7091808142a7df891L203-R204)
* Improved the `renderStaticCellLinks` method to include logging and handle null checks more effectively.
* Simplified event listener setup in `setupAutoReRenderOfCellLinksOnWindowEvents` for better readability and maintainability.

### Miscellaneous:
* Updated the `logo` method in `MatchElement.scala` to use the new `.logo-40` class.
* Made the `seGetTeams` method in `package.scala` more flexible by providing a default parameter value.